### PR TITLE
corrected group id parsing

### DIFF
--- a/cgate.js
+++ b/cgate.js
@@ -144,7 +144,7 @@ function parseMessage(data,type) {
 
     // last element of arr2 is the group
     temp = array[2].match(/\d+/g);
-    packet.group = temp[2];
+    packet.group = temp[3];
 
     var parseunit = array[3];
     var parseoid = array[4];


### PR DESCRIPTION
Fixed parsing of group to be last element of array[2], this was returning the application rather than the group meaning loss of sync with the DB level and group level
